### PR TITLE
Transform IN and EQ queries on the diagnosis_available attribute

### DIFF
--- a/molgenis-app-bbmri-eric/src/main/java/org/molgenis/app/bbmri/eric/CollectionsQueryTransformerImpl.java
+++ b/molgenis-app-bbmri-eric/src/main/java/org/molgenis/app/bbmri/eric/CollectionsQueryTransformerImpl.java
@@ -4,33 +4,25 @@ import org.molgenis.data.DataService;
 import org.molgenis.data.Entity;
 import org.molgenis.data.Query;
 import org.molgenis.data.QueryRule;
-import org.molgenis.data.meta.model.Attribute;
-import org.molgenis.data.meta.model.EntityType;
-import org.molgenis.data.support.QueryImpl;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
+import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 @Component
 public class CollectionsQueryTransformerImpl implements CollectionsQueryTransformer
 {
-	private static final String COLLECTIONS_ID = "eu_bbmri_eric_collections";
 	private static final String DISEASE_TYPES_ENTITY_ID = "eu_bbmri_eric_disease_types";
-	private static final String DISEASE_TYPES_ATTRIBUTE_CODE = "code";
-	private static final String DISEASE_TYPES_ATTRIBUTE_LABEL = "label";
 	private static final String DISEASE_TYPES_ATTRIBUTE_DIAGNOSIS_AVAILABLE = "diagnosis_available";
 
 	private final Icd10ClassExpander icd10ClassExpander;
 	private final DataService dataService;
 
-	public CollectionsQueryTransformerImpl(Icd10ClassExpander icd10ClassExpander,
-			DataService dataService)
+	public CollectionsQueryTransformerImpl(Icd10ClassExpander icd10ClassExpander, DataService dataService)
 	{
 		this.icd10ClassExpander = requireNonNull(icd10ClassExpander);
 		this.dataService = requireNonNull(dataService);
@@ -39,94 +31,65 @@ public class CollectionsQueryTransformerImpl implements CollectionsQueryTransfor
 	@Override
 	public Query<Entity> transformQuery(Query<Entity> query)
 	{
-		Query<Entity> transformedQuery;
 		if (isTransformableQuery(query))
 		{
-			String queryValue = query.getRules().get(0).getValue().toString();
-
-			List<Entity> diseaseTypes = findDiseaseTypes(queryValue).collect(toList());
-			if (!diseaseTypes.isEmpty())
+			query.getRules().forEach(rule ->
 			{
-				transformedQuery = createTransformedQuery(query, queryValue, diseaseTypes);
-			}
-			else
-			{
-				transformedQuery = query;
-			}
+				if (rule.getField().equals(DISEASE_TYPES_ATTRIBUTE_DIAGNOSIS_AVAILABLE))
+				{
+					transformQueryRule(rule);
+				}
+			});
 		}
-		else
+
+		return query;
+	}
+
+	private void transformQueryRule(QueryRule rule)
+	{
+		List<Object> queryValues;
+
+		switch (rule.getOperator())
 		{
-			transformedQuery = query;
+			case EQUALS:
+				queryValues = singletonList(rule.getValue());
+				rule.setOperator(QueryRule.Operator.IN);
+				break;
+			case IN:
+				//noinspection unchecked
+				queryValues = (List<Object>) rule.getValue();
+				break;
+			default:
+				throw new IllegalStateException("Can't expand queries other than IN or EQUALS");
 		}
-		return transformedQuery;
-	}
 
-	private Query<Entity> createTransformedQuery(Query<Entity> query, String queryValue, List<Entity> diseaseTypes)
-	{
-		Query<Entity> transformedQuery = new QueryImpl<>();
-		transformedQuery.pageSize(query.getPageSize());
-		transformedQuery.offset(query.getOffset());
-		transformedQuery.sort(query.getSort());
-		transformedQuery.fetch(query.getFetch());
+		List<Entity> diseaseTypes = dataService.findAll(DISEASE_TYPES_ENTITY_ID, queryValues.stream())
+											   .collect(toList());
 
-		getSearchableAttributeNames().forEach(attrName -> transformedQuery.search(attrName, queryValue).or());
-
-		Collection<Entity> expandedDiseaseTypes = expandDiseaseTypes(diseaseTypes);
-		transformedQuery.in(DISEASE_TYPES_ATTRIBUTE_DIAGNOSIS_AVAILABLE, expandedDiseaseTypes);
-		return transformedQuery;
+		rule.setValue(expandDiseaseTypes(diseaseTypes));
 	}
 
 	/**
-	 * Returns the attributes of the BBMRI-ERIC collections entity type that can be used in a query with operator SEARCH.
+	 * Returns <code>true</code> if query has a rule 'IN' or 'EQUALS' on the diagnosis_available attribute
 	 */
-	private Stream<String> getSearchableAttributeNames()
+	private boolean isTransformableQuery(Query<Entity> q)
 	{
-		EntityType entityType = dataService.getEntityType(COLLECTIONS_ID);
-		return StreamSupport.stream(entityType.getAtomicAttributes().spliterator(), false)
-				.filter(this::isSearchableAttribute).map(Attribute::getName);
-	}
-
-	/**
-	 * Returns whether the given attribute can be used in a query with operator SEARCH.
-	 */
-	private boolean isSearchableAttribute(Attribute attribute)
-	{
-		if (attribute.getName().equals(DISEASE_TYPES_ATTRIBUTE_DIAGNOSIS_AVAILABLE))
+		if (q.getRules() == null || q.getRules().isEmpty())
 		{
 			return false;
 		}
 
-		switch (attribute.getDataType())
+		for (QueryRule rule : q.getRules())
 		{
-			case BOOL:
-			case DATE:
-			case DATE_TIME:
-			case DECIMAL:
-			case INT:
-			case LONG:
-				return false;
-			default:
+
+			if (rule.getField() != null && rule.getField().equals(DISEASE_TYPES_ATTRIBUTE_DIAGNOSIS_AVAILABLE) && (
+					rule.getOperator() == QueryRule.Operator.IN || rule.getOperator() == QueryRule.Operator.EQUALS))
+			{
 				return true;
+			}
 		}
-	}
 
-	/**
-	 * Returns <code>true</code> if query has one rule 'SEARCH sometext'
-	 */
-	private boolean isTransformableQuery(Query<Entity> q)
-	{
-		return q.getRules() != null && q.getRules().size() == 1
-				&& q.getRules().get(0).getOperator() == QueryRule.Operator.SEARCH
-				&& q.getRules().get(0).getField() == null;
-	}
-
-	/**
-	 * Find disease type entities that match the given query text.
-	 */
-	private Stream<Entity> findDiseaseTypes(String queryValue)
-	{
-		return dataService.query(DISEASE_TYPES_ENTITY_ID).eq(DISEASE_TYPES_ATTRIBUTE_CODE, queryValue).or()
-				.search(DISEASE_TYPES_ATTRIBUTE_LABEL, queryValue).findAll();
+		return false;
 	}
 
 	/**

--- a/molgenis-app-bbmri-eric/src/main/java/org/molgenis/app/bbmri/eric/CollectionsRepositoryDecorator.java
+++ b/molgenis-app-bbmri-eric/src/main/java/org/molgenis/app/bbmri/eric/CollectionsRepositoryDecorator.java
@@ -14,51 +14,61 @@ import static java.util.Objects.requireNonNull;
 
 public class CollectionsRepositoryDecorator extends AbstractRepositoryDecorator<Entity>
 {
-	private final Repository<Entity> decoratedRepository;
+	static final String COLLECTIONS_ID = "eu_bbmri_eric_collections";
+
 	private final CollectionsQueryTransformer queryTransformer;
 
-	public CollectionsRepositoryDecorator(Repository<Entity> decoratedRepository,
-			CollectionsQueryTransformer queryTransformer)
+	CollectionsRepositoryDecorator(Repository<Entity> decoratedRepository, CollectionsQueryTransformer queryTransformer)
 	{
 		super(decoratedRepository);
-		this.decoratedRepository = requireNonNull(decoratedRepository);
 		this.queryTransformer = requireNonNull(queryTransformer);
 	}
 
 	@Override
-	public Repository<Entity> delegate()
+	public long count(Query<Entity> query)
 	{
-		return decoratedRepository;
+		if (isCollectionsEntityType())
+		{
+			query = query != null ? queryTransformer.transformQuery(query) : null;
+		}
+		return delegate().count(query);
 	}
 
 	@Override
-	public long count(Query<Entity> q)
+	public Entity findOne(Query<Entity> query)
 	{
-		Query<Entity> transformedQuery = q != null ? queryTransformer.transformQuery(q) : null;
-		return super.count(transformedQuery);
+		if (isCollectionsEntityType())
+		{
+			query = query != null ? queryTransformer.transformQuery(query) : null;
+		}
+		return delegate().findOne(query);
 	}
 
 	@Override
-	public Entity findOne(Query<Entity> q)
+	public Stream<Entity> findAll(Query<Entity> query)
 	{
-		Query<Entity> transformedQuery = q != null ? queryTransformer.transformQuery(q) : null;
-		return super.findOne(transformedQuery);
-	}
-
-	@Override
-	public Stream<Entity> findAll(Query<Entity> q)
-	{
-		Query<Entity> transformedQuery = q != null ? queryTransformer.transformQuery(q) : null;
-		return super.findAll(transformedQuery);
+		if (isCollectionsEntityType())
+		{
+			query = query != null ? queryTransformer.transformQuery(query) : null;
+		}
+		return delegate().findAll(query);
 	}
 
 	@Override
 	public AggregateResult aggregate(AggregateQuery aggregateQuery)
 	{
-		Query<Entity> q = aggregateQuery.getQuery();
-		Query<Entity> transformedQuery = q != null ? queryTransformer.transformQuery(q) : null;
-		AggregateQuery transformedAggregateQuery = new AggregateQueryImpl(aggregateQuery.getAttributeX(),
-				aggregateQuery.getAttributeY(), aggregateQuery.getAttributeDistinct(), transformedQuery);
-		return super.aggregate(transformedAggregateQuery);
+		if (isCollectionsEntityType())
+		{
+			Query<Entity> q = aggregateQuery.getQuery();
+			Query<Entity> transformedQuery = q != null ? queryTransformer.transformQuery(q) : null;
+			aggregateQuery = new AggregateQueryImpl(aggregateQuery.getAttributeX(), aggregateQuery.getAttributeY(),
+					aggregateQuery.getAttributeDistinct(), transformedQuery);
+		}
+		return delegate().aggregate(aggregateQuery);
+	}
+
+	private boolean isCollectionsEntityType()
+	{
+		return getEntityType().getId().equals(COLLECTIONS_ID);
 	}
 }

--- a/molgenis-app-bbmri-eric/src/test/java/org/molgenis/app/bbmri/eric/CollectionsRepositoryDecoratorTest.java
+++ b/molgenis-app-bbmri-eric/src/test/java/org/molgenis/app/bbmri/eric/CollectionsRepositoryDecoratorTest.java
@@ -4,6 +4,7 @@ import org.mockito.Mock;
 import org.molgenis.data.Entity;
 import org.molgenis.data.Query;
 import org.molgenis.data.Repository;
+import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.test.AbstractMockitoTest;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -12,8 +13,8 @@ import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.molgenis.app.bbmri.eric.CollectionsRepositoryDecorator.COLLECTIONS_ID;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class CollectionsRepositoryDecoratorTest extends AbstractMockitoTest
 {
@@ -31,14 +32,12 @@ public class CollectionsRepositoryDecoratorTest extends AbstractMockitoTest
 	@BeforeMethod
 	public void setUpBeforeMethod()
 	{
+		EntityType entityType = mock(EntityType.class);
+		when(decoratedRepository.getEntityType()).thenReturn(entityType);
+		when(entityType.getId()).thenReturn(COLLECTIONS_ID);
+
 		when(queryTransformer.transformQuery(query)).thenReturn(transformedQuery);
 		collectionsRepositoryDecorator = new CollectionsRepositoryDecorator(decoratedRepository, queryTransformer);
-	}
-
-	@Test
-	public void testDelegate() throws Exception
-	{
-		assertEquals(collectionsRepositoryDecorator.delegate(), decoratedRepository);
 	}
 
 	@Test


### PR DESCRIPTION
- Fixes bug where you couldn't use search on any table other than 'collections'
- No longer does query expansion on SEARCH queries
- Expands queries on the 'diagnosis_available` attribute if they are IN or EQUALS. Result query should contain at least an IN rule with the expanded classes.
- **Note:** Tests still fail. Beware: ```CollectionsQueryTransformerImplTest``` uses mocks in its data provider! This doesn't work and the old test is probably incorrect.

How to test:
- Import https://drive.google.com/open?id=0B_An6CB5WwrvZEhwcThHbHV4RE0
- Go to 'collections' entity and open filter wizard
- In the 'donor data' tab, for 'diagnosis available` select 'C00-C97' (and optionally other values)
- Confirm that that the 
Biobank-University Hospitals Leuven,
Asklepios Biobank fuer Lungenerkrankungen,
Stiftung PATH - Patients' Tumor Bank of Hope,
Translational Sarcoma Research Network,
NHS Grampian Biorepository
,Cambridge Blood and Stem Cell Biobank
are found
- use google search with the same term
- Confirm nothing is found
